### PR TITLE
Print error if output file is not writable

### DIFF
--- a/include/generator/fblas_generator.hpp
+++ b/include/generator/fblas_generator.hpp
@@ -62,6 +62,10 @@ public:
         json_writer.EndArray();
         json_writer.EndObject();
         std::ofstream fout(output_dir+"generated_routines.json");
+        if(!fout.is_open()){
+            std::cerr << "Error in opening output file generated_routines.json (file path: "<<output_dir<<")"<<std::endl;
+            return;
+        }
         fout << s.GetString();
         fout.close();
 

--- a/src/generator/host_api_level1_generators.cpp
+++ b/src/generator/host_api_level1_generators.cpp
@@ -17,11 +17,15 @@ void FBlasGenerator::Level1Swap(const GeneratorRoutine &r, unsigned int id, std:
 {
     std::ifstream fin(k_skeleton_folder_ + "/1/streaming_swap.cl");
     if(!fin.is_open()){
-        std::cerr << "Error in opening skeleton file for "<< r.getBlasName() << "(file path: "<<k_skeleton_folder_<<")"<<std::endl;
+        std::cerr << "Error in opening skeleton file for "<< r.getBlasName() << " (file path: "<<k_skeleton_folder_<<")"<<std::endl;
         return;
     }
 
     std::ofstream fout(output_folder+r.getUserName()+".cl");
+    if(!fout.is_open()){
+        std::cerr << "Error in opening output file for "<< r.getUserName() << " (file path: "<<output_folder<<")"<<std::endl;
+        return;
+    }
     fout << k_generated_file_header_<<std::endl;
 
     bool found_placeholder=FBlasGenerator::CopyHeader(fin,fout);
@@ -73,11 +77,15 @@ void FBlasGenerator::Level1Rot(const GeneratorRoutine &r, unsigned int id, std::
 {
     std::ifstream fin(k_skeleton_folder_ + "/1/streaming_rot.cl");
     if(!fin.is_open()){
-        std::cerr << "Error in opening skeleton file for "<< r.getBlasName() << "(file path: "<<k_skeleton_folder_<<")"<<std::endl;
+        std::cerr << "Error in opening skeleton file for "<< r.getBlasName() << " (file path: "<<k_skeleton_folder_<<")"<<std::endl;
         return;
     }
 
     std::ofstream fout(output_folder+r.getUserName()+".cl");
+    if(!fout.is_open()){
+        std::cerr << "Error in opening output file for "<< r.getUserName() << " (file path: "<<output_folder<<")"<<std::endl;
+        return;
+    }
     fout << k_generated_file_header_<<std::endl;
 
     bool found_placeholder=FBlasGenerator::CopyHeader(fin,fout);
@@ -129,11 +137,15 @@ void FBlasGenerator::Level1Rotm(const GeneratorRoutine &r, unsigned int id, std:
 {
     std::ifstream fin(k_skeleton_folder_ + "/1/streaming_rotm.cl");
     if(!fin.is_open()){
-        std::cerr << "Error in opening skeleton file for "<< r.getBlasName() << "(file path: "<<k_skeleton_folder_<<")"<<std::endl;
+        std::cerr << "Error in opening skeleton file for "<< r.getBlasName() << " (file path: "<<k_skeleton_folder_<<")"<<std::endl;
         return;
     }
 
     std::ofstream fout(output_folder+r.getUserName()+".cl");
+    if(!fout.is_open()){
+        std::cerr << "Error in opening output file for "<< r.getUserName() << " (file path: "<<output_folder<<")"<<std::endl;
+        return;
+    }
     fout << k_generated_file_header_<<std::endl;
 
     bool found_placeholder=FBlasGenerator::CopyHeader(fin,fout);
@@ -188,6 +200,10 @@ void FBlasGenerator::Level1Rotg(const GeneratorRoutine &r, unsigned int id, std:
     //Therefore the output of the generation will be just an empty file
     //This has been done for compatibility with respect to the rest of the library and to leave space for further modifications
     std::ofstream fout(output_folder+r.getUserName()+".cl");
+    if(!fout.is_open()){
+        std::cerr << "Error in opening output file for "<< r.getUserName() << " (file path: "<<output_folder<<")"<<std::endl;
+        return;
+    }
     fout << k_generated_file_header_<<std::endl;
     fout << "__kernel void empty_"<<id<<"(){ /*empty kernel, used for rotg*/}"<<std::endl;
 
@@ -220,6 +236,10 @@ void FBlasGenerator::Level1Rotmg(const GeneratorRoutine &r, unsigned int id, std
     //Therefore the output of the generation will be just an empty file
     //This has been done for compatibility with respect to the rest of the library and to leave space for further modifications
     std::ofstream fout(output_folder+r.getUserName()+".cl");
+    if(!fout.is_open()){
+        std::cerr << "Error in opening output file for "<< r.getUserName() << " (file path: "<<output_folder<<")"<<std::endl;
+        return;
+    }
     fout << k_generated_file_header_<<std::endl;
     fout << "__kernel void empty_"<<id<<"(){ /*empty kernel, used for rotmg*/}"<<std::endl;
     json_writer.StartObject();
@@ -249,11 +269,15 @@ void FBlasGenerator::Level1Axpy(const GeneratorRoutine &r, unsigned int id, std:
 {
     std::ifstream fin(k_skeleton_folder_ + "/1/streaming_axpy.cl");
     if(!fin.is_open()){
-        std::cerr << "Error in opening skeleton file for "<< r.getBlasName() << "(file path: "<<k_skeleton_folder_<<")"<<std::endl;
+        std::cerr << "Error in opening skeleton file for "<< r.getBlasName() << " (file path: "<<k_skeleton_folder_<<")"<<std::endl;
         return;
     }
 
     std::ofstream fout(output_folder+r.getUserName()+".cl");
+    if(!fout.is_open()){
+        std::cerr << "Error in opening output file for "<< r.getUserName() << " (file path: "<<output_folder<<")"<<std::endl;
+        return;
+    }
     fout << k_generated_file_header_<<std::endl;
 
     bool found_placeholder=FBlasGenerator::CopyHeader(fin,fout);
@@ -307,11 +331,15 @@ void FBlasGenerator::Level1Dot(const GeneratorRoutine &r, unsigned int id, std::
 
     std::ifstream fin(k_skeleton_folder_ + "/1/streaming_dot.cl");
     if(!fin.is_open()){
-        std::cerr << "Error in opening skeleton file for "<< r.getBlasName() << "(file path: "<<k_skeleton_folder_<<")"<<std::endl;
+        std::cerr << "Error in opening skeleton file for "<< r.getBlasName() << " (file path: "<<k_skeleton_folder_<<")"<<std::endl;
         return;
     }
 
     std::ofstream fout(output_folder+r.getUserName()+".cl");
+    if(!fout.is_open()){
+        std::cerr << "Error in opening output file for "<< r.getUserName() << " (file path: "<<output_folder<<")"<<std::endl;
+        return;
+    }
     fout << k_generated_file_header_<<std::endl;
 
     bool found_placeholder=FBlasGenerator::CopyHeader(fin,fout);
@@ -364,11 +392,15 @@ void FBlasGenerator::Level1Scal(const GeneratorRoutine &r, unsigned int id, std:
 
     std::ifstream fin(k_skeleton_folder_ + "/1/streaming_scal.cl");
     if(!fin.is_open()){
-        std::cerr << "Error in opening skeleton file for "<< r.getBlasName() << "(file path: "<<k_skeleton_folder_<<")"<<std::endl;
+        std::cerr << "Error in opening skeleton file for "<< r.getBlasName() << " (file path: "<<k_skeleton_folder_<<")"<<std::endl;
         return;
     }
 
     std::ofstream fout(output_folder+r.getUserName()+".cl");
+    if(!fout.is_open()){
+        std::cerr << "Error in opening output file for "<< r.getUserName() << " (file path: "<<output_folder<<")"<<std::endl;
+        return;
+    }
     fout << k_generated_file_header_<<std::endl;
 
     bool found_placeholder=FBlasGenerator::CopyHeader(fin,fout);
@@ -418,11 +450,15 @@ void FBlasGenerator::Level1Asum(const GeneratorRoutine &r, unsigned int id, std:
 
     std::ifstream fin(k_skeleton_folder_ + "/1/streaming_asum.cl");
     if(!fin.is_open()){
-        std::cerr << "Error in opening skeleton file for "<< r.getBlasName() << "(file path: "<<k_skeleton_folder_<<")"<<std::endl;
+        std::cerr << "Error in opening skeleton file for "<< r.getBlasName() << " (file path: "<<k_skeleton_folder_<<")"<<std::endl;
         return;
     }
 
     std::ofstream fout(output_folder+r.getUserName()+".cl");
+    if(!fout.is_open()){
+        std::cerr << "Error in opening output file for "<< r.getUserName() << " (file path: "<<output_folder<<")"<<std::endl;
+        return;
+    }
     fout << k_generated_file_header_<<std::endl;
 
     bool found_placeholder=FBlasGenerator::CopyHeader(fin,fout);
@@ -470,11 +506,15 @@ void FBlasGenerator::Level1Iamax(const GeneratorRoutine &r, unsigned int id, std
 
     std::ifstream fin(k_skeleton_folder_ + "/1/streaming_iamax.cl");
     if(!fin.is_open()){
-        std::cerr << "Error in opening skeleton file for "<< r.getBlasName() << "(file path: "<<k_skeleton_folder_<<")"<<std::endl;
+        std::cerr << "Error in opening skeleton file for "<< r.getBlasName() << " (file path: "<<k_skeleton_folder_<<")"<<std::endl;
         return;
     }
 
     std::ofstream fout(output_folder+r.getUserName()+".cl");
+    if(!fout.is_open()){
+        std::cerr << "Error in opening output file for "<< r.getUserName() << " (file path: "<<output_folder<<")"<<std::endl;
+        return;
+    }
     fout << k_generated_file_header_<<std::endl;
 
     bool found_placeholder=FBlasGenerator::CopyHeader(fin,fout);
@@ -522,11 +562,15 @@ void FBlasGenerator::Level1Nrm2(const GeneratorRoutine &r, unsigned int id, std:
 
     std::ifstream fin(k_skeleton_folder_ + "/1/streaming_nrm2.cl");
     if(!fin.is_open()){
-        std::cerr << "Error in opening skeleton file for "<< r.getBlasName() << "(file path: "<<k_skeleton_folder_<<")"<<std::endl;
+        std::cerr << "Error in opening skeleton file for "<< r.getBlasName() << " (file path: "<<k_skeleton_folder_<<")"<<std::endl;
         return;
     }
 
     std::ofstream fout(output_folder+r.getUserName()+".cl");
+    if(!fout.is_open()){
+        std::cerr << "Error in opening output file for "<< r.getUserName() << " (file path: "<<output_folder<<")"<<std::endl;
+        return;
+    }
     fout << k_generated_file_header_<<std::endl;
 
     bool found_placeholder=FBlasGenerator::CopyHeader(fin,fout);
@@ -576,6 +620,10 @@ void FBlasGenerator::Level1Copy(const GeneratorRoutine &r, unsigned int id, std:
     //Copy is created by using the vector reader and writer helpers
     //The generation is very peculiar
     std::ofstream fout(output_folder+r.getUserName()+".cl");
+    if(!fout.is_open()){
+        std::cerr << "Error in opening output file for "<< r.getUserName() << " (file path: "<<output_folder<<")"<<std::endl;
+        return;
+    }
     fout << k_generated_file_header_<<std::endl;
     fout << "#pragma OPENCL EXTENSION cl_intel_channels : enable" <<std::endl;
 

--- a/src/generator/host_api_level2_generators.cpp
+++ b/src/generator/host_api_level2_generators.cpp
@@ -29,11 +29,15 @@ void FBlasGenerator::Level2Gemv(const GeneratorRoutine &r, unsigned int id, std:
         fin.open(k_skeleton_folder_ + "/2/streaming_gemv_v2.cl");
 
     if(!fin.is_open()){
-        std::cerr << "Error in opening skeleton file for "<< r.getBlasName() << "(file path: "<<k_skeleton_folder_<<")"<<std::endl;
+        std::cerr << "Error in opening skeleton file for "<< r.getBlasName() << " (file path: "<<k_skeleton_folder_<<")"<<std::endl;
         return;
     }
 
     std::ofstream fout(output_folder+r.getUserName()+".cl");
+    if(!fout.is_open()){
+        std::cerr << "Error in opening output file for "<< r.getUserName() << " (file path: "<<output_folder<<")"<<std::endl;
+        return;
+    }
 
     bool found_placeholder=FBlasGenerator::CopyHeader(fin,fout);
     if(!found_placeholder)
@@ -124,11 +128,15 @@ void FBlasGenerator::Level2Trmv(const GeneratorRoutine &r, unsigned int id, std:
         fin.open(k_skeleton_folder_ + "/2/streaming_gemv_v2.cl");
 
     if(!fin.is_open()){
-        std::cerr << "Error in opening skeleton file for "<< r.getBlasName() << "(file path: "<<k_skeleton_folder_<<")"<<std::endl;
+        std::cerr << "Error in opening skeleton file for "<< r.getBlasName() << " (file path: "<<k_skeleton_folder_<<")"<<std::endl;
         return;
     }
 
     std::ofstream fout(output_folder+r.getUserName()+".cl");
+    if(!fout.is_open()){
+        std::cerr << "Error in opening output file for "<< r.getUserName() << " (file path: "<<output_folder<<")"<<std::endl;
+        return;
+    }
 
     bool found_placeholder=FBlasGenerator::CopyHeader(fin,fout);
     if(!found_placeholder)
@@ -219,11 +227,15 @@ void FBlasGenerator::Level2Symv(const GeneratorRoutine &r, unsigned int id, std:
         fin.open(k_skeleton_folder_ + "/2/streaming_gemv_v1.cl");
 
     if(!fin.is_open()){
-        std::cerr << "Error in opening skeleton file for "<< r.getBlasName() << "(file path: "<<k_skeleton_folder_<<")"<<std::endl;
+        std::cerr << "Error in opening skeleton file for "<< r.getBlasName() << " (file path: "<<k_skeleton_folder_<<")"<<std::endl;
         return;
     }
 
     std::ofstream fout(output_folder+r.getUserName()+".cl");
+    if(!fout.is_open()){
+        std::cerr << "Error in opening output file for "<< r.getUserName() << " (file path: "<<output_folder<<")"<<std::endl;
+        return;
+    }
 
     bool found_placeholder=FBlasGenerator::CopyHeader(fin,fout);
     if(!found_placeholder)
@@ -309,11 +321,15 @@ void FBlasGenerator::Level2Ger(const GeneratorRoutine &r, unsigned int id, std::
         fin.open(k_skeleton_folder_ + "/2/streaming_ger_v1.cl");
 
     if(!fin.is_open()){
-        std::cerr << "Error in opening skeleton file for "<< r.getBlasName() << "(file path: "<<k_skeleton_folder_<<")"<<std::endl;
+        std::cerr << "Error in opening skeleton file for "<< r.getBlasName() << " (file path: "<<k_skeleton_folder_<<")"<<std::endl;
         return;
     }
 
     std::ofstream fout(output_folder+r.getUserName()+".cl");
+    if(!fout.is_open()){
+        std::cerr << "Error in opening output file for "<< r.getUserName() << " (file path: "<<output_folder<<")"<<std::endl;
+        return;
+    }
 
     bool found_placeholder=FBlasGenerator::CopyHeader(fin,fout);
     if(!found_placeholder)
@@ -392,11 +408,15 @@ void FBlasGenerator::Level2Syr(const GeneratorRoutine &r, unsigned int id, std::
         fin.open(k_skeleton_folder_ + "/2/streaming_syr_v2.cl");
 
     if(!fin.is_open()){
-        std::cerr << "Error in opening skeleton file for "<< r.getBlasName() << "(file path: "<<k_skeleton_folder_<<")"<<std::endl;
+        std::cerr << "Error in opening skeleton file for "<< r.getBlasName() << " (file path: "<<k_skeleton_folder_<<")"<<std::endl;
         return;
     }
 
     std::ofstream fout(output_folder+r.getUserName()+".cl");
+    if(!fout.is_open()){
+        std::cerr << "Error in opening output file for "<< r.getUserName() << " (file path: "<<output_folder<<")"<<std::endl;
+        return;
+    }
 
     bool found_placeholder=FBlasGenerator::CopyHeader(fin,fout);
     if(!found_placeholder)
@@ -483,11 +503,15 @@ void FBlasGenerator::Level2Syr2(const GeneratorRoutine &r, unsigned int id, std:
         fin.open(k_skeleton_folder_ + "/2/streaming_syr2_v2.cl");
 
     if(!fin.is_open()){
-        std::cerr << "Error in opening skeleton file for "<< r.getBlasName() << "(file path: "<<k_skeleton_folder_<<")"<<std::endl;
+        std::cerr << "Error in opening skeleton file for "<< r.getBlasName() << " (file path: "<<k_skeleton_folder_<<")"<<std::endl;
         return;
     }
 
     std::ofstream fout(output_folder+r.getUserName()+".cl");
+    if(!fout.is_open()){
+        std::cerr << "Error in opening output file for "<< r.getUserName() << " (file path: "<<output_folder<<")"<<std::endl;
+        return;
+    }
 
     bool found_placeholder=FBlasGenerator::CopyHeader(fin,fout);
     if(!found_placeholder)
@@ -589,11 +613,15 @@ void FBlasGenerator::Level2Trsv(const GeneratorRoutine &r, unsigned int id, std:
         fin.open(k_skeleton_folder_ + "/2/streaming_trsv_v4.cl");
 
     if(!fin.is_open()){
-        std::cerr << "Error in opening skeleton file for "<< r.getBlasName() << "(file path: "<<k_skeleton_folder_<<")"<<std::endl;
+        std::cerr << "Error in opening skeleton file for "<< r.getBlasName() << " (file path: "<<k_skeleton_folder_<<")"<<std::endl;
         return;
     }
 
     std::ofstream fout(output_folder+r.getUserName()+".cl");
+    if(!fout.is_open()){
+        std::cerr << "Error in opening output file for "<< r.getUserName() << " (file path: "<<output_folder<<")"<<std::endl;
+        return;
+    }
 
     bool found_placeholder=FBlasGenerator::CopyHeader(fin,fout);
     if(!found_placeholder)

--- a/src/generator/host_api_level3_generators.cpp
+++ b/src/generator/host_api_level3_generators.cpp
@@ -27,11 +27,15 @@ void FBlasGenerator::Level3Gemm(const GeneratorRoutine &r, unsigned int id, std:
         fin.open(k_skeleton_folder_ + "/3/gemm.cl");
 
     if(!fin.is_open()){
-        std::cerr << "Error in opening skeleton file for "<< r.getBlasName() << "(file path: "<<k_skeleton_folder_<<")"<<std::endl;
+        std::cerr << "Error in opening skeleton file for "<< r.getBlasName() << " (file path: "<<k_skeleton_folder_<<")"<<std::endl;
         return;
     }
 
     std::ofstream fout(output_folder+r.getUserName()+".cl");
+    if(!fout.is_open()){
+        std::cerr << "Error in opening output file for "<< r.getUserName() << " (file path: "<<output_folder<<")"<<std::endl;
+        return;
+    }
 
     bool found_placeholder=FBlasGenerator::CopyHeader(fin,fout);
     if(!found_placeholder)
@@ -99,11 +103,15 @@ void FBlasGenerator::Level3Syrk(const GeneratorRoutine &r, unsigned int id, std:
         fin.open(k_skeleton_folder_ + "/3/syrk.cl");
 
     if(!fin.is_open()){
-        std::cerr << "Error in opening skeleton file for "<< r.getBlasName() << "(file path: "<<k_skeleton_folder_<<")"<<std::endl;
+        std::cerr << "Error in opening skeleton file for "<< r.getBlasName() << " (file path: "<<k_skeleton_folder_<<")"<<std::endl;
         return;
     }
 
     std::ofstream fout(output_folder+r.getUserName()+".cl");
+    if(!fout.is_open()){
+        std::cerr << "Error in opening output file for "<< r.getUserName() << " (file path: "<<output_folder<<")"<<std::endl;
+        return;
+    }
 
     bool found_placeholder=FBlasGenerator::CopyHeader(fin,fout);
     if(!found_placeholder)
@@ -176,11 +184,15 @@ void FBlasGenerator::Level3Syr2k(const GeneratorRoutine &r, unsigned int id, std
         fin.open(k_skeleton_folder_ + "/3/syr2k.cl");
 
     if(!fin.is_open()){
-        std::cerr << "Error in opening skeleton file for "<< r.getBlasName() << "(file path: "<<k_skeleton_folder_<<")"<<std::endl;
+        std::cerr << "Error in opening skeleton file for "<< r.getBlasName() << " (file path: "<<k_skeleton_folder_<<")"<<std::endl;
         return;
     }
 
     std::ofstream fout(output_folder+r.getUserName()+".cl");
+    if(!fout.is_open()){
+        std::cerr << "Error in opening output file for "<< r.getUserName() << " (file path: "<<output_folder<<")"<<std::endl;
+        return;
+    }
 
     bool found_placeholder=FBlasGenerator::CopyHeader(fin,fout);
     if(!found_placeholder)
@@ -284,11 +296,15 @@ void FBlasGenerator::Level3Trsm(const GeneratorRoutine &r, unsigned int id, std:
 
 
     if(!fin.is_open()){
-        std::cerr << "Error in opening skeleton file for "<< r.getBlasName() << "(file path: "<<k_skeleton_folder_<<")"<<std::endl;
+        std::cerr << "Error in opening skeleton file for "<< r.getBlasName() << " (file path: "<<k_skeleton_folder_<<")"<<std::endl;
         return;
     }
 
     std::ofstream fout(output_folder+r.getUserName()+".cl");
+    if(!fout.is_open()){
+        std::cerr << "Error in opening output file for "<< r.getUserName() << " (file path: "<<output_folder<<")"<<std::endl;
+        return;
+    }
 
     bool found_placeholder=FBlasGenerator::CopyHeader(fin,fout);
     if(!found_placeholder)

--- a/src/generator/modules_helper_generators.cpp
+++ b/src/generator/modules_helper_generators.cpp
@@ -18,10 +18,14 @@ void ModuleGenerator::ReadVectorX(const GeneratorHelper &h, unsigned int id, std
 
     std::ifstream fin(k_skeleton_folder_ + "/helpers/read_vector_x.cl");
     if(!fin.is_open()){
-        std::cerr << "Error in opening skeleton file for "<< h.getType() << "(file path: "<<k_skeleton_folder_<<")"<<std::endl;
+        std::cerr << "Error in opening skeleton file for "<< h.getType() << " (file path: "<<k_skeleton_folder_<<")"<<std::endl;
         return;
     }
     std::ofstream fout(output_folder+h.getUserName()+".cl");
+    if(!fout.is_open()){
+        std::cerr << "Error in opening output file for "<< h.getUserName() << " (file path: "<<output_folder<<")"<<std::endl;
+        return;
+    }
     fout << k_channel_enable_define_<<std::endl;
     if(h.isDoublePrecision())
         fout << k_double_precision_define_ <<std::endl;
@@ -46,10 +50,14 @@ void ModuleGenerator::ReadVectorY(const GeneratorHelper &h, unsigned int id, std
 
     std::ifstream fin(k_skeleton_folder_ + "/helpers/read_vector_y.cl");
     if(!fin.is_open()){
-        std::cerr << "Error in opening skeleton file for "<< h.getType() << "(file path: "<<k_skeleton_folder_<<")"<<std::endl;
+        std::cerr << "Error in opening skeleton file for "<< h.getType() << " (file path: "<<k_skeleton_folder_<<")"<<std::endl;
         return;
     }
     std::ofstream fout(output_folder+h.getUserName()+".cl");
+    if(!fout.is_open()){
+        std::cerr << "Error in opening output file for "<< h.getUserName() << " (file path: "<<output_folder<<")"<<std::endl;
+        return;
+    }
     fout << k_channel_enable_define_<<std::endl;
     if(h.isDoublePrecision())
         fout << k_double_precision_define_ <<std::endl;
@@ -71,10 +79,14 @@ void ModuleGenerator::WriteScalar(const GeneratorHelper &h, unsigned int id, std
 
     std::ifstream fin(k_skeleton_folder_ + "/helpers/write_scalar.cl");
     if(!fin.is_open()){
-        std::cerr << "Error in opening skeleton file for "<< h.getType() << "(file path: "<<k_skeleton_folder_<<")"<<std::endl;
+        std::cerr << "Error in opening skeleton file for "<< h.getType() << " (file path: "<<k_skeleton_folder_<<")"<<std::endl;
         return;
     }
     std::ofstream fout(output_folder+h.getUserName()+".cl");
+    if(!fout.is_open()){
+        std::cerr << "Error in opening output file for "<< h.getUserName() << " (file path: "<<output_folder<<")"<<std::endl;
+        return;
+    }
     fout << k_channel_enable_define_<<std::endl;
     if(h.isDoublePrecision())
         fout << k_double_precision_define_ <<std::endl;
@@ -96,10 +108,14 @@ void ModuleGenerator::WriteVector(const GeneratorHelper &h, unsigned int id, std
 
     std::ifstream fin(k_skeleton_folder_ + "/helpers/write_vector.cl");
     if(!fin.is_open()){
-        std::cerr << "Error in opening skeleton file for "<< h.getType() << "(file path: "<<k_skeleton_folder_<<")"<<std::endl;
+        std::cerr << "Error in opening skeleton file for "<< h.getType() << " (file path: "<<k_skeleton_folder_<<")"<<std::endl;
         return;
     }
     std::ofstream fout(output_folder+h.getUserName()+".cl");
+    if(!fout.is_open()){
+        std::cerr << "Error in opening output file for "<< h.getUserName() << " (file path: "<<output_folder<<")"<<std::endl;
+        return;
+    }
     fout << k_channel_enable_define_<<std::endl;
     if(h.isDoublePrecision())
         fout << k_double_precision_define_ <<std::endl;
@@ -129,10 +145,14 @@ void ModuleGenerator::ReadMatrix(const GeneratorHelper &h, unsigned int id, std:
 
     std::ifstream fin(k_skeleton_folder_ +skeleton_name);
     if(!fin.is_open()){
-        std::cerr << "Error in opening skeleton file for "<< h.getType() << "(file path: "<<k_skeleton_folder_<<")"<<std::endl;
+        std::cerr << "Error in opening skeleton file for "<< h.getType() << " (file path: "<<k_skeleton_folder_<<")"<<std::endl;
         return;
     }
     std::ofstream fout(output_folder+h.getUserName()+".cl");
+    if(!fout.is_open()){
+        std::cerr << "Error in opening output file for "<< h.getUserName() << " (file path: "<<output_folder<<")"<<std::endl;
+        return;
+    }
     fout << k_channel_enable_define_<<std::endl;
     if(h.isDoublePrecision())
         fout << k_double_precision_define_ <<std::endl;
@@ -165,10 +185,14 @@ void ModuleGenerator::WriteMatrix(const GeneratorHelper &h, unsigned int id, std
 
     std::ifstream fin(k_skeleton_folder_ +skeleton_name);
     if(!fin.is_open()){
-        std::cerr << "Error in opening skeleton file for "<< h.getType() << "(file path: "<<k_skeleton_folder_<<")"<<std::endl;
+        std::cerr << "Error in opening skeleton file for "<< h.getType() << " (file path: "<<k_skeleton_folder_<<")"<<std::endl;
         return;
     }
     std::ofstream fout(output_folder+h.getUserName()+".cl");
+    if(!fout.is_open()){
+        std::cerr << "Error in opening output file for "<< h.getUserName() << " (file path: "<<output_folder<<")"<<std::endl;
+        return;
+    }
     fout << k_channel_enable_define_<<std::endl;
     if(h.isDoublePrecision())
         fout << k_double_precision_define_ <<std::endl;

--- a/src/generator/modules_level1_generators.cpp
+++ b/src/generator/modules_level1_generators.cpp
@@ -18,11 +18,15 @@ void ModuleGenerator::Level1Dot(const GeneratorRoutine &r, unsigned int id, std:
 
     std::ifstream fin(k_skeleton_folder_ + "/1/streaming_dot.cl");
     if(!fin.is_open()){
-        std::cerr << "Error in opening skeleton file for "<< r.getBlasName() << "(file path: "<<k_skeleton_folder_<<")"<<std::endl;
+        std::cerr << "Error in opening skeleton file for "<< r.getBlasName() << " (file path: "<<k_skeleton_folder_<<")"<<std::endl;
         return;
     }
 
     std::ofstream fout(output_folder+r.getUserName()+".cl");
+    if(!fout.is_open()){
+        std::cerr << "Error in opening output file for "<< r.getUserName() << " (file path: "<<output_folder<<")"<<std::endl;
+        return;
+    }
 
     bool found_placeholder=ModuleGenerator::CopyHeader(fin,fout);
     if(!found_placeholder)
@@ -57,11 +61,15 @@ void ModuleGenerator::Level1Axpy(const GeneratorRoutine &r, unsigned int id, std
 
     std::ifstream fin(k_skeleton_folder_ + "/1/streaming_axpy.cl");
     if(!fin.is_open()){
-        std::cerr << "Error in opening skeleton file for "<< r.getBlasName() << "(file path: "<<k_skeleton_folder_<<")"<<std::endl;
+        std::cerr << "Error in opening skeleton file for "<< r.getBlasName() << " (file path: "<<k_skeleton_folder_<<")"<<std::endl;
         return;
     }
 
     std::ofstream fout(output_folder+r.getUserName()+".cl");
+    if(!fout.is_open()){
+        std::cerr << "Error in opening output file for "<< r.getUserName() << " (file path: "<<output_folder<<")"<<std::endl;
+        return;
+    }
 
     bool found_placeholder=ModuleGenerator::CopyHeader(fin,fout);
     if(!found_placeholder)

--- a/src/generator/modules_level2_generators.cpp
+++ b/src/generator/modules_level2_generators.cpp
@@ -30,11 +30,15 @@ void ModuleGenerator::Level2Gemv(const GeneratorRoutine &r, unsigned int id, std
 
     std::ifstream fin(k_skeleton_folder_ + skeleton_name);
     if(!fin.is_open()){
-        std::cerr << "Error in opening skeleton file for "<< r.getBlasName() << "(file path: "<<k_skeleton_folder_<<")"<<std::endl;
+        std::cerr << "Error in opening skeleton file for "<< r.getBlasName() << " (file path: "<<k_skeleton_folder_<<")"<<std::endl;
         return;
     }
 
     std::ofstream fout(output_folder+r.getUserName()+".cl");
+    if(!fout.is_open()){
+        std::cerr << "Error in opening output file for "<< r.getUserName() << " (file path: "<<output_folder<<")"<<std::endl;
+        return;
+    }
 
     bool found_placeholder=ModuleGenerator::CopyHeader(fin,fout);
     if(!found_placeholder)
@@ -84,11 +88,15 @@ void ModuleGenerator::Level2Ger(const GeneratorRoutine &r, unsigned int id, std:
 
     std::ifstream fin(k_skeleton_folder_ + skeleton_name);
     if(!fin.is_open()){
-        std::cerr << "Error in opening skeleton file for "<< r.getBlasName() << "(file path: "<<k_skeleton_folder_<<")"<<std::endl;
+        std::cerr << "Error in opening skeleton file for "<< r.getBlasName() << " (file path: "<<k_skeleton_folder_<<")"<<std::endl;
         return;
     }
 
     std::ofstream fout(output_folder+r.getUserName()+".cl");
+    if(!fout.is_open()){
+        std::cerr << "Error in opening output file for "<< r.getUserName() << " (file path: "<<output_folder<<")"<<std::endl;
+        return;
+    }
 
     bool found_placeholder=ModuleGenerator::CopyHeader(fin,fout);
     if(!found_placeholder)


### PR DESCRIPTION
Since the default location for output files is /tmp, this can quickly occur on systems shared by multiple users. At least print an error message so the user knows that the files could not be properly generated.

While here, introduce a missing space into the error message for non-readable skeletons.